### PR TITLE
Оптимизация структуры domain_list_: переход на указатели вместо строк

### DIFF
--- a/DNS_Cache/DNSCache.h
+++ b/DNS_Cache/DNSCache.h
@@ -5,7 +5,6 @@
 #include <unordered_map>
 #include <list>
 #include <mutex>
-#include <shared_mutex>
 #include "custom_hash.h"
 
 class DNSCache {
@@ -25,12 +24,12 @@ private:
 
     struct CacheData {
         std::string ip;
-        std::list<std::string>::iterator pos_in_domain_list_;
+        std::list<const std::string*>::iterator pos_in_domain_list_;
     };
 
     size_t max_size_;
     std::unordered_map<std::string, CacheData, custom_hash> dns_map_;
-    std::list<std::string> domain_list_;
+    std::list<const std::string*> domain_list_;
 
     std::mutex mutex_;
 };


### PR DESCRIPTION
В domain_list_ теперь хранятся указатели на строки, которые являются ключами dns_map_. Это позволяет сэкономить память, избегая дублирования данных.